### PR TITLE
Add 'phrases' to ALLOWED_FIELDS for audio transcription task, fix tests

### DIFF
--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -20,7 +20,7 @@ ALLOWED_FIELDS = {'categorization': {'attachment', 'attachment_type', 'categorie
                   'lineannotation': {'attachment', 'attachment_type', 'instruction',
                                  'objects_to_annotate', 'with_labels', 'examples'},
                   'datacollection': {'attachment', 'attachment_type', 'fields'},
-                  'audiotranscription': {'attachment', 'attachment_type', 'verbatim'}}
+                  'audiotranscription': {'attachment', 'attachment_type', 'verbatim', 'phrases'}}
 SCALE_ENDPOINT = 'https://api.scaleapi.com/v1/'
 DEFAULT_LIMIT = 100
 DEFAULT_OFFSET = 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -186,7 +186,8 @@ def test_audiotranscription_ok():
         callback_url='http://www.example.com/callback',
         attachment_type='audio',
         attachment='https://storage.googleapis.com/deepmind-media/pixie/knowing-what-to-say/second-list/speaker-3.wav',
-        verbatim=False
+        verbatim=False,
+        phrases=['avocado', 'stone']
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -62,6 +62,7 @@ def test_transcription_fail():
             attachment_type='website')
 
 
+@pytest.mark.skip(reason="Deprecated at the moment")
 def test_phonecall_ok():
     task = client.create_phonecall_task(
         callback_url='http://www.example.com/callback',
@@ -73,6 +74,7 @@ def test_phonecall_ok():
         choices=['He is happy', 'He is not happy'])
 
 
+@pytest.mark.skip(reason="Deprecated at the moment")
 def test_phonecall_fail():
     with pytest.raises(scaleapi.ScaleInvalidRequest):
         client.create_phonecall_task(


### PR DESCRIPTION
and also mark the `task/phonecall` endpoint tests for pytest to skip for now, since tox was failing and I saw the message on the support Slack regarding that one's deprecation.

If I'm being too forward with the latter change, I can limit my PR to just the former change.