### PR TITLE
Only install enum34 on python before 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ try:
 except ImportError:
     from distutils.core import setup
 
-install_requires = ['requests>=2.4.2', 'enum34']
+install_requires = ['requests>=2.4.2']
+
+if sys.version_info < (3, 4, 0):
+    install_requires.append('enum34')
 
 if sys.version_info < (2, 7, 9):
     warnings.warn(


### PR DESCRIPTION
enum34 is a package that backports python 3.4 enum functionality to earlier
versions. However, it only includes the functionality as of 3.4. If other
packages use more recent enum functionality, this will break them. (See #17
for more details.)

The solution is just to install enum34 only when the python version is
pre-3.4.

Fixes #17 