### PR TITLE
replaced fetch_task with get_task

### DIFF
--- a/scaleapi/tasks.py
+++ b/scaleapi/tasks.py
@@ -81,7 +81,7 @@ class Task:
 
     def refresh(self):
         """Refreshes the task details."""
-        self._json = self._client.fetch_task(self.id).as_dict()
+        self._json = self._client.get_task(self.id).as_dict()
 
     def cancel(self):
         """Cancels the task"""


### PR DESCRIPTION
`fetch_task` is deprecated, and replaced with `get_task`