### PR TITLE
Handling 503 Response Code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -322,7 +322,8 @@ as a `ScaleException` parent type and child exceptions:
 - ``ScaleResourceNotFound``: 404 - Not Found -- The requested resource doesn't exist.
 - ``ScaleDuplicateTask``: 409 - Conflict -- The provided idempotency key or unique_id is already in use for a different request.
 - ``ScaleTooManyRequests``: 429 - Too Many Requests -- Too many requests hit the API too quickly.
-- ``ScaleInternalError``: 500 - Internal Server Error -- We had a problem with our server. Try again later
+- ``ScaleInternalError``: 500 - Internal Server Error -- We had a problem with our server. Try again later.
+- ``ScaleServiceUnavailable``: 503 - Server Timeout From Request Queueing -- Try again later.
 - ``ScaleTimeoutError``: 504 - Server Timeout Error -- Try again later.
 
 Check out `Scale's API documentation <https://docs.scale.com/reference#errors>`_ for more details.

--- a/scaleapi/_version.py
+++ b/scaleapi/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 __package_name__ = "scaleapi"

--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -12,7 +12,7 @@ SCALE_ENDPOINT = "https://api.scale.com/v1"
 # Parameters for HTTP retry
 HTTP_TOTAL_RETRIES = 3  # Number of total retries
 HTTP_RETRY_BACKOFF_FACTOR = 2  # Wait 1, 2, 4 seconds between retries
-HTTP_STATUS_FORCE_LIST = [429, 500, 504]  # Status codes to force retry
+HTTP_STATUS_FORCE_LIST = [429, 500, 503, 504]  # Status codes to force retry
 HTTP_RETRY_ALLOWED_METHODS = frozenset({"GET", "POST"})
 
 
@@ -68,7 +68,6 @@ class Api:
     @staticmethod
     def _raise_on_respose(res: Response):
 
-        message = ""
         try:
             message = res.json().get("error", res.text)
         except ValueError:
@@ -78,7 +77,7 @@ class Api:
             exception = ExceptionMap[res.status_code]
             raise exception(message)
         except KeyError as err:
-            raise ScaleException(message) from err
+            raise ScaleException(message, res.status_code) from err
 
     def _api_request(
         self, method, endpoint, headers=None, auth=None, params=None, body=None

--- a/scaleapi/exceptions.py
+++ b/scaleapi/exceptions.py
@@ -69,6 +69,12 @@ class ScaleInternalError(ScaleException):
     code = 500
 
 
+class ScaleServiceUnavailable(ScaleException):
+    """503 - Server Timeout From Request Queueing -- Try again later."""
+
+    code = 503
+
+
 class ScaleTimeoutError(ScaleException):
     """504 - Server Timeout Error -- Try again later."""
 
@@ -84,4 +90,5 @@ ExceptionMap = {
     ScaleTooManyRequests.code: ScaleTooManyRequests,
     ScaleInternalError.code: ScaleInternalError,
     ScaleTimeoutError.code: ScaleTimeoutError,
+    ScaleServiceUnavailable.code: ScaleServiceUnavailable,
 }


### PR DESCRIPTION
SDK now recognizes the `503` Response Code and applies retry since it's a timeout kind of error, driven by the backend.