### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ __ https://docs.scale.com/reference#batch-creation
     client.create_batch(
         project = "test_project",
         callback = "http://www.example.com/callback",
-        name = "batch_name_01_07_2021"
+        batch_name = "batch_name_01_07_2021"
     )
 
 Finalize Batch


### PR DESCRIPTION
Parameter is `batch_name` and not `name` 

https://github.com/scaleapi/scaleapi-python-client/blob/09cbad504fd47f7d6c7d71ffbd531f4bfbcbf7a8/scaleapi/__init__.py#L320