### PR TITLE
Add self_serve arg to project creation.

### DIFF
--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -504,7 +504,11 @@ class ScaleClient:
             has_more = batches.has_more
 
     def create_project(
-        self, project_name: str, task_type: TaskType, params: Dict = None, self_serve: bool = False,
+        self,
+        project_name: str,
+        task_type: TaskType,
+        params: Dict = None,
+        self_serve: bool = False,
     ) -> Project:
         """Creates a new project.
         https://docs.scale.com/reference#project-creation
@@ -524,7 +528,12 @@ class ScaleClient:
             Project: [description]
         """
         endpoint = "projects"
-        payload = dict(type=task_type.value, name=project_name, params=params, self_serve=self_serve)
+        payload = dict(
+            type=task_type.value,
+            name=project_name,
+            params=params,
+            self_serve=self_serve,
+        )
         projectdata = self.api.post_request(endpoint, body=payload)
         return Project(projectdata, self)
 

--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -504,7 +504,7 @@ class ScaleClient:
             has_more = batches.has_more
 
     def create_project(
-        self, project_name: str, task_type: TaskType, params: Dict = None
+        self, project_name: str, task_type: TaskType, params: Dict = None, self_serve: bool = False,
     ) -> Project:
         """Creates a new project.
         https://docs.scale.com/reference#project-creation
@@ -524,7 +524,7 @@ class ScaleClient:
             Project: [description]
         """
         endpoint = "projects"
-        payload = dict(type=task_type.value, name=project_name, params=params)
+        payload = dict(type=task_type.value, name=project_name, params=params, self_serve=self_serve)
         projectdata = self.api.post_request(endpoint, body=payload)
         return Project(projectdata, self)
 


### PR DESCRIPTION
Adds arg self_serve to project creation function

Support for this has now been added to the Scale's project creation API and the docs are updated https://docs.scale.com/reference#project-creation