### PR TITLE
Remove json from HTTP requests for ScaleGov

### DIFF
--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -61,7 +61,7 @@ class Api:
 
         try:
             params = params or {}
-            body = body or {}
+            body = body or None
 
             res = https.request(
                 method=method,


### PR DESCRIPTION
Our ScaleGov environment has an AWS WAF (Web Application Firewall) that errors out on any GET request that has a `json` parameter (for some reason or another)

Tested with the ScaleGov API, also tested with the Commercial API with `pytest test_client.py` and it seemed to be fine 