### PR TITLE
False 500 testing

### DIFF
--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -115,12 +115,14 @@ class Api:
             # RequestHistory(method='POST', url='/v1/task/imageannotation', error=None, status=409, redirect_location=None)
             if retry_history != ():
                 # See if the first retry was a 500 error
-                if retry_history[0][3] == 500: # Changed to 409 to easily test by running test_unique_id_fail
-                    uuid = body['unique_id']
-                    newUrl = f'https://api.scale.com/v1/tasks?unique_id={uuid}'
+                if retry_history[0][3] == 500:
+                    uuid = body["unique_id"]
+                    newUrl = f"https://api.scale.com/v1/tasks?unique_id={uuid}"
                     # grab task response via uuid by hitting /tasks endpoint
-                    newRes = self._http_request("GET", newUrl, headers=headers, auth=auth)
-                    json = newRes.json()['docs'][0]
+                    newRes = self._http_request(
+                        "GET", newUrl, headers=headers, auth=auth
+                    )
+                    json = newRes.json()["docs"][0]
             else:
                 self._raise_on_respose(res)
         else:

--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -116,15 +116,17 @@ class Api:
             if retry_history != ():
                 # See if the first retry was a 500 error
                 # Change to 409 to easily test by running test_unique_id_fail
-                if retry_history[0][3] == 500:
-                    print(res.json())
-                    print(body['unique_id'])
-                    # grab task response via uuid by hitting /tasks endpoint?
-                    # newRes = self._http_request('GET', '/v1/tasks, headers, auth, params, body, files, data)
-                    # json = newRes.json()
+                if retry_history[0][3] == 409:
+                    uuid = body['unique_id']
+                    newParams = f'?unique_id={uuid}'
+                    newUrl = f'https://api.scale.com/v1/tasks?unique_id={uuid}'
+                    print(newUrl)
+                    # grab task response via uuid by hitting /tasks endpoint
+                    newRes = self._http_request("GET", newUrl, headers=headers, auth=auth)
+                    json = newRes.json()['docs'][0]
+                    print(json)
         else:
             self._raise_on_respose(res)
-        print('Going to return the json now')
         return json
 
     def get_request(self, endpoint, params=None):

--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -121,6 +121,8 @@ class Api:
                     # grab task response via uuid by hitting /tasks endpoint
                     newRes = self._http_request("GET", newUrl, headers=headers, auth=auth)
                     json = newRes.json()['docs'][0]
+            else:
+                self._raise_on_respose(res)
         else:
             self._raise_on_respose(res)
         return json

--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -12,7 +12,7 @@ SCALE_API_BASE_URL_V1 = "https://api.scale.com/v1"
 # Parameters for HTTP retry
 HTTP_TOTAL_RETRIES = 3  # Number of total retries
 HTTP_RETRY_BACKOFF_FACTOR = 2  # Wait 1, 2, 4 seconds between retries
-HTTP_STATUS_FORCE_LIST = [408, 409, 429] + list(range(500, 531))
+HTTP_STATUS_FORCE_LIST = [408, 429] + list(range(500, 531))
 HTTP_RETRY_ALLOWED_METHODS = frozenset({"GET", "POST", "DELETE"})
 
 
@@ -115,7 +115,7 @@ class Api:
             # RequestHistory(method='POST', url='/v1/task/imageannotation', error=None, status=409, redirect_location=None)
             if retry_history != ():
                 # See if the first retry was a 500 error
-                if retry_history[0][3] == 409: # Changed to 409 to easily test by running test_unique_id_fail
+                if retry_history[0][3] == 500: # Changed to 409 to easily test by running test_unique_id_fail
                     uuid = body['unique_id']
                     newUrl = f'https://api.scale.com/v1/tasks?unique_id={uuid}'
                     # grab task response via uuid by hitting /tasks endpoint

--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -109,7 +109,7 @@ class Api:
         json = None
         if res.status_code == 200:
             json = res.json()
-        elif res.status_code == 409:
+        elif res.status_code == 409 and 'task' in endpoint and body.get('unique_id'):
             retry_history = res.raw.retries.history
             # Example RequestHistory tuple
             # RequestHistory(method='POST',
@@ -121,7 +121,7 @@ class Api:
                 # See if the first retry was a 500 error
                 if retry_history[0][3] == 500:
                     uuid = body["unique_id"]
-                    newUrl = f"https://api.scale.com/v1/tasks?unique_id={uuid}"
+                    newUrl = f"{self.base_api_url}/tasks?unique_id={uuid}"
                     # grab task from api
                     newRes = self._http_request(
                         "GET", newUrl, headers=headers, auth=auth

--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -115,16 +115,12 @@ class Api:
             # RequestHistory(method='POST', url='/v1/task/imageannotation', error=None, status=409, redirect_location=None)
             if retry_history != ():
                 # See if the first retry was a 500 error
-                # Change to 409 to easily test by running test_unique_id_fail
-                if retry_history[0][3] == 409:
+                if retry_history[0][3] == 409: # Changed to 409 to easily test by running test_unique_id_fail
                     uuid = body['unique_id']
-                    newParams = f'?unique_id={uuid}'
                     newUrl = f'https://api.scale.com/v1/tasks?unique_id={uuid}'
-                    print(newUrl)
                     # grab task response via uuid by hitting /tasks endpoint
                     newRes = self._http_request("GET", newUrl, headers=headers, auth=auth)
                     json = newRes.json()['docs'][0]
-                    print(json)
         else:
             self._raise_on_respose(res)
         return json

--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -112,13 +112,17 @@ class Api:
         elif res.status_code == 409:
             retry_history = res.raw.retries.history
             # Example RequestHistory tuple
-            # RequestHistory(method='POST', url='/v1/task/imageannotation', error=None, status=409, redirect_location=None)
+            # RequestHistory(method='POST',
+            #   url='/v1/task/imageannotation',
+            #   error=None,
+            #   status=409,
+            #   redirect_location=None)
             if retry_history != ():
                 # See if the first retry was a 500 error
                 if retry_history[0][3] == 500:
                     uuid = body["unique_id"]
                     newUrl = f"https://api.scale.com/v1/tasks?unique_id={uuid}"
-                    # grab task response via uuid by hitting /tasks endpoint
+                    # grab task from api
                     newRes = self._http_request(
                         "GET", newUrl, headers=headers, auth=auth
                     )

--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -109,7 +109,7 @@ class Api:
         json = None
         if res.status_code == 200:
             json = res.json()
-        elif res.status_code == 409 and 'task' in endpoint and body.get('unique_id'):
+        elif res.status_code == 409 and "task" in endpoint and body.get("unique_id"):
             retry_history = res.raw.retries.history
             # Example RequestHistory tuple
             # RequestHistory(method='POST',


### PR DESCRIPTION
Here's the test on Python that's run with Pytest:
<img width="535" alt="Screen Shot 2022-10-17 at 7 16 43 PM" src="https://user-images.githubusercontent.com/76976063/196320190-44d1c118-29d0-452b-8769-4ceee61bf9d9.png">
<img width="1437" alt="Screen Shot 2022-10-17 at 7 15 30 PM" src="https://user-images.githubusercontent.com/76976063/196320168-e52a35a3-dad1-470e-88d5-81be563cff57.png">

Here's the console.logs from the local-machine where I'm "reproducing" a similar error (returns 500, but successfully creates task):
<img width="647" alt="Screen Shot 2022-10-17 at 7 16 19 PM" src="https://user-images.githubusercontent.com/76976063/196320327-1e2ef624-abb3-45c2-bbf8-e9014d175cb1.png">
<img width="1046" alt="Screen Shot 2022-10-17 at 7 16 07 PM" src="https://user-images.githubusercontent.com/76976063/196320490-15d069e6-bbf2-4766-843e-d9240224df5a.png">

So, the test for this was kinda weird, I made our task creation handler force an error during the first task creation. This had to be forced after the task has been created, but before the 200 is sent back. 

The same error can't happen on the second task creation, but it should fail in a 409 