### PR TITLE
Introduce a PR template to the repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+# Pull Request Summary
+
+## Description
+
+_Please include a summary of the changes. Please also include the relevant context and motivation. List any dependencies and assumptions that are required for this change._
+
+
+## How did you test your code?
+
+_Which of the following have you done to test your changes? Please describe the tests that you ran to verify your changes._
+- [ ] Created new unit tests in `tests/` for the newly implemented methods
+- [ ] Updated existing unit tests in `tests/` to cover changes made to existing methods
+
+
+## Checklist
+
+_Please make sure all items in this checklist have been fulfilled before sending your PR out for review!_
+
+- [ ] I have commented my code in details, particularly in hard-to-understand areas
+- [ ] I have updated [Readme.rst](https://github.com/scaleapi/scaleapi-python-client/blob/master/README.rst) document with examples for newly implemented public methods
+- [ ] I have reviewed [Deployment and Publishing Guide for Python SDK](https://github.com/scaleapi/scaleapi-python-client/blob/master/docs/pypi_update_guide.md) document
+- [ ] I incremented the SDK version in `_version.py` _(unless this PR only updates the documentation)._
+- [ ] In order to release a new version, a "Release Summary" needs to be prepared and published after the merge


### PR DESCRIPTION
Adding a PR template for the repo to ensure developers follow certain guidance (testing, documentation) and to remind them to review the deployment guide and include version increments if needed in their PRs.