### PR TITLE
bumping incremental version

### DIFF
--- a/scaleapi/_version.py
+++ b/scaleapi/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.10.0"
+__version__ = "2.10.1"
 __package_name__ = "scaleapi"


### PR DESCRIPTION
Bumping version for incremental release

Draft Release here: https://github.com/scaleapi/scaleapi-python-client/releases/edit/untagged-d5d4cd9c3d7b2339c10e

Referencing this pr: https://github.com/scaleapi/scaleapi-python-client/pull/57