### PR TITLE
Add task audit endpoints to SDK

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,6 +239,27 @@ __ https://docs.scale.com/reference#cancel-task
     task.cancel(clear_unique_id=True)
 
 
+Audit a Task
+^^^^^^^^^^^^
+
+This method allows you to ``accept`` or ``reject`` completed tasks, along with support for adding comments about the reason for the given audit status, mirroring our Audit UI.
+Check out `Scale's API documentation`__ for more information.
+
+__ https://docs.scale.com/reference/audit-a-task
+
+.. code-block :: python
+
+    # Accept a completed task by submitting an audit
+    client.audit_task('30553edd0b6a93f8f05f0fee', True)
+
+    # Reject a completed task by submitting a comment with the audit
+    client.audit_task('30553edd0b6a93f8f05f0fee', False, 'Rejected due to quality')
+
+    # audit() is also available on Task object
+    task = client.get_task('30553edd0b6a93f8f05f0fee')
+    task.audit(True)
+
+
 Update A Task's Unique Id
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -83,6 +83,23 @@ class ScaleClient:
             endpoint = f"task/{task_id}/cancel"
         return Task(self.api.post_request(endpoint), self)
 
+    def audit_task(self, task_id: str, accepted: bool, comments: str = None):
+        """Allows you to accept or reject completed tasks.
+        Along with support for adding comments about the reason
+        for the given audit status, mirroring our Audit UI.
+
+        Args:
+            task_id (str):
+                Task id
+            accepted (boolean):
+                Optional, additional feedback to record the reason
+                for the audit status
+        """
+
+        payload = dict(accepted=accepted, comments=comments)
+        endpoint = f"task/{task_id}/audit"
+        return self.api.post_request(endpoint, body=payload)
+
     def update_task_unique_id(self, task_id: str, unique_id: str) -> Task:
         """Updates a task's unique_id and returns the associated task.
         Raises a ScaleDuplicateResource exception if unique_id

--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -98,7 +98,7 @@ class ScaleClient:
 
         payload = dict(accepted=accepted, comments=comments)
         endpoint = f"task/{task_id}/audit"
-        return self.api.post_request(endpoint, body=payload)
+        self.api.post_request(endpoint, body=payload)
 
     def update_task_unique_id(self, task_id: str, unique_id: str) -> Task:
         """Updates a task's unique_id and returns the associated task.

--- a/scaleapi/_version.py
+++ b/scaleapi/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.10.1"
+__version__ = "2.11.0"
 __package_name__ = "scaleapi"

--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -108,7 +108,11 @@ class Api:
 
         json = None
         if res.status_code == 200:
-            json = res.json()
+            try:
+                json = res.json()
+            except ValueError:
+                # Some endpoints only return 'OK' message without JSON
+                return json
         elif res.status_code == 409 and "task" in endpoint and body.get("unique_id"):
             retry_history = res.raw.retries.history
             # Example RequestHistory tuple

--- a/scaleapi/tasks.py
+++ b/scaleapi/tasks.py
@@ -88,6 +88,10 @@ class Task:
         """Cancels the task"""
         self._client.cancel_task(self.id, clear_unique_id)
 
+    def audit(self, accepted: bool, comments: str = None):
+        """Submit an audit to a completed task"""
+        self._client.audit_task(self.id, accepted, comments)
+
     def update_unique_id(self, unique_id: str):
         """Updates unique_id of a task"""
         self._client.update_task_unique_id(self.id, unique_id)


### PR DESCRIPTION
# Pull Request Summary

- Implementing existing task accept/reject API for audits to SDK
- `client.audit_task()` as well as `task.audit()` are implemented methods
- Readme is updated with examples

`TODO:` Testing of audit endpoint via test task/project is not available so that part is to-be implemented later.

## Description

Implementing already existing audit API endpoint into the SDK.
https://docs.scale.com/reference/audit-a-task


## How did you test your code?

_Which of the following have you done to test your changes? Please describe the tests that you ran to verify your changes._
- [ ] Created new unit tests in `tests/` for the newly implemented methods
- [ ] Updated existing unit tests in `tests/` to cover changes made to existing methods


## Checklist

_Please make sure all items in this checklist have been fulfilled before sending your PR out for review!_

- [x] I have commented my code in details, particularly in hard-to-understand areas
- [x] I have updated [Readme.rst](https://github.com/scaleapi/scaleapi-python-client/blob/master/README.rst) document with examples for newly implemented public methods
- [x] I have reviewed [Deployment and Publishing Guide for Python SDK](https://github.com/scaleapi/scaleapi-python-client/blob/master/docs/pypi_update_guide.md) document
- [x] I incremented the SDK version in `_version.py` _(unless this PR only updates the documentation)._
- [x] In order to release a new version, a "Release Summary" needs to be prepared and published after the merge
