### PR TITLE
Fix minor typo in get_tasks code sample

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,7 +193,7 @@ __ https://docs.scale.com/reference#list-multiple-tasks
 
     # For retrieving results as a Task list
     task_list = list(tasks)
-    print(f"{len(task_list))} tasks retrieved")
+    print(f"{len(task_list)} tasks retrieved")
 
 Get Tasks Count
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Pull Request Summary

## Description

The sample line `print(f"{len(task_list))} tasks retrieved")` has an extra `)` in it. Let's fix that.