### PR TITLE
adding proxy support to SDK

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,24 @@ _____
 
     client = scaleapi.ScaleClient("YOUR_API_KEY_HERE")
 
+If you need to use a proxy to connect Scale API, you can feed ``proxies``, ``cert`` and ``verify`` attributes of the python ``requests`` package during the client initialization.
+Proxy support is available with SDK version 2.14.0 and beyond.
+
+`Documentation of Proxies usage in requests package`__
+
+__ https://requests.readthedocs.io/en/latest/user/advanced/#proxies
+
+.. code-block:: python
+
+    proxies = { 'https': 'http://10.10.1.10:1080' }
+
+    client = scaleapi.ScaleClient(
+                api_key="YOUR_API_KEY_HERE",
+                proxies=proxies,
+                cert='/path/client.cert',
+                verify=True
+            )
+
 Tasks
 _____
 
@@ -358,7 +376,7 @@ __ https://docs.scale.com/reference/deleting-tags
     # delete a list of tags on a task by specifying task id
     tags_to_delete = ["tag1", "tag2"]
     task = client.delete_task_tags('30553edd0b6a93f8f05f0fee', tags_to_delete)
-    
+
     # delete a list of tags on a task object
     task = client.get_task('30553edd0b6a93f8f05f0fee')
     tags_to_delete = ["tag1", "tag2"]
@@ -600,7 +618,7 @@ The attribute can be passed to the task payloads, in the ``attachment`` paramete
       ...
       ...
   )
-  
+
 Manage Teammates
 ________________
 
@@ -628,9 +646,9 @@ Returns all teammates in a List of Teammate objects.
 .. code-block:: python
 
     from scaleapi import TeammateRole
-    
+
     teammates = client.invite_teammates(['email1@example.com', 'email2@example.com'], TeammateRole.Member)
-    
+
 Update Teammate Role
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -641,7 +659,7 @@ Returns all teammates in a List of Teammate objects.
 .. code-block python
 
     from scaleapi import TeammateRole
-    
+
     teammates = client.update_teammates_role(['email1@example.com', 'email2@example.com'], TeammateRole.Manager)
 
 Example Scripts
@@ -738,7 +756,7 @@ Manage project assignments for your labelers.
 List All Assignments
 ^^^^^^^^^^^^^^^^^^^^
 
-Lists all your Scale team members and the projects they are assigned to. 
+Lists all your Scale team members and the projects they are assigned to.
 Returns a dictionary of all teammate assignments with keys as 'emails' of each teammate, and values as a list of project names the teammate are assigned to.
 
 .. code-block:: python
@@ -772,7 +790,7 @@ Returns a dictionary of all teammate assignments with keys as 'emails' of each t
 .. code-block:: python
 
     assignments = client.remove_studio_assignments(['email1@example.com', 'email2@example.com'], ['project 1', 'project 2'])
-    
+
 Studio Project Groups (For Scale Studio Only)
 _____________________________________________
 
@@ -784,7 +802,7 @@ List Studio Project Groups
 Returns all labeler groups for the specified project.
 
 .. code-block:: python
-    
+
     list_project_group = client.list_project_groups('project_name')
 
 Add Studio Project Group
@@ -803,7 +821,7 @@ Returns the created StudioProjectGroup object.
 Update Studio Project Group
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Assign or remove teammates from a project group. 
+Assign or remove teammates from a project group.
 
 Returns the updated StudioProjectGroup object.
 
@@ -812,7 +830,7 @@ Returns the updated StudioProjectGroup object.
     updated_project_group = client.update_project_group(
         'project_name', 'project_group_name', ['emails_to_add'], ['emails_to_remove']
     )
-    
+
 Studio Batches (For Scale Studio Only)
 _______________________________________
 
@@ -835,7 +853,7 @@ Sets labeler group assignment for the specified batch.
 Returns a StudioBatch object for the specified batch.
 
 .. code-block:: python
-    
+
     assigned_studio_batch = client.assign_studio_batches('batch_name', ['project_group_name'])
 
 Set Studio Batches Priority

--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -48,11 +48,22 @@ class Batchlist(Paginator[Batch]):
 class ScaleClient:
     """Main class serves as an interface for Scale API"""
 
-    def __init__(self, api_key, source=None, api_instance_url=None):
+    def __init__(
+        self,
+        api_key,
+        source=None,
+        api_instance_url=None,
+        verify=None,
+        proxies=None,
+        cert=None,
+    ):
         self.api = Api(
             api_key,
             user_agent_extension=source,
             api_instance_url=api_instance_url,
+            verify=verify,
+            proxies=proxies,
+            cert=cert,
         )
 
     def get_task(self, task_id: str) -> Task:

--- a/scaleapi/_version.py
+++ b/scaleapi/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.13.0"
+__version__ = "2.14.0"
 __package_name__ = "scaleapi"


### PR DESCRIPTION
# Pull Request Summary

- Adding proxy support to SDK Client initialization. Now users can pass `proxies`, `cert` and `verify` parameters to their `requests`

```py
    proxies = { 'https': 'http://10.10.1.10:1080' }
    
    client = scaleapi.ScaleClient(
                api_key="YOUR_API_KEY_HERE",
                proxies=proxies,
                cert='/path/client.cert',
                verify=True
            )
```

## Description

_Please include a summary of the changes. Please also include the relevant context and motivation. List any dependencies and assumptions that are required for this change._


## How did you test your code?

_Which of the following have you done to test your changes? Please describe the tests that you ran to verify your changes._
- [ ] Created new unit tests in `tests/` for the newly implemented methods
- [ ] Updated existing unit tests in `tests/` to cover changes made to existing methods


## Checklist

_Please make sure all items in this checklist have been fulfilled before sending your PR out for review!_

- [x] I have commented my code in details, particularly in hard-to-understand areas
- [x] I have updated [Readme.rst](https://github.com/scaleapi/scaleapi-python-client/blob/master/README.rst) document with examples for newly implemented public methods
- [x] I have reviewed [Deployment and Publishing Guide for Python SDK](https://github.com/scaleapi/scaleapi-python-client/blob/master/docs/pypi_update_guide.md) document
- [x] I incremented the SDK version in `_version.py` _(unless this PR only updates the documentation)._
- [ ] In order to release a new version, a "Release Summary" needs to be prepared and published after the merge
