### PR TITLE
add attachment url option flag

### DIFF
--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -269,6 +269,10 @@ class ScaleClient:
             limit (int):
                 Determines the page size (1-100)
 
+            include_attachment_url (bool):
+                If true, returns a pre-signed s3 url for the
+                attachment used to create the task.
+
             next_token (str):
                 Can be use to fetch the next page of tasks
         """
@@ -288,6 +292,7 @@ class ScaleClient:
             "updated_before",
             "updated_after",
             "unique_id",
+            "include_attachment_url",
         }
 
         for key in kwargs:
@@ -323,6 +328,7 @@ class ScaleClient:
         created_after: str = None,
         created_before: str = None,
         tags: Union[List[str], str] = None,
+        include_attachment_url: bool = True,
     ) -> Generator[Task, None, None]:
         """Retrieve all tasks as a `generator` method, with the
         given parameters. This methods handles pagination of
@@ -382,6 +388,11 @@ class ScaleClient:
                 The tags of a task; multiple tags can be
                 specified as a list.
 
+            include_attachment_url (bool):
+                If true, returns a pre-signed s3 url for the
+                attachment used to create the task.
+
+
         Yields:
             Generator[Task]:
                 Yields Task objects, can be iterated.
@@ -404,6 +415,7 @@ class ScaleClient:
             created_after,
             created_before,
             tags,
+            include_attachment_url,
         )
 
         while has_more:
@@ -431,6 +443,7 @@ class ScaleClient:
         created_after: str = None,
         created_before: str = None,
         tags: Union[List[str], str] = None,
+        include_attachment_url: bool = True,
     ) -> int:
         """Returns number of tasks with given filters.
 
@@ -485,6 +498,10 @@ class ScaleClient:
                 The tags of a task; multiple tags can be
                 specified as a list.
 
+            include_attachment_url (bool):
+                If true, returns a pre-signed s3 url for the
+                attachment used to create the task.
+
         Returns:
             int:
                 Returns number of tasks
@@ -504,6 +521,7 @@ class ScaleClient:
             created_after,
             created_before,
             tags,
+            include_attachment_url,
         )
 
         tasks_args["limit"] = 1
@@ -526,6 +544,7 @@ class ScaleClient:
         created_after: str = None,
         created_before: str = None,
         tags: Union[List[str], str] = None,
+        include_attachment_url: bool = True,
     ):
         """Generates args for /tasks endpoint."""
         tasks_args = {
@@ -539,6 +558,7 @@ class ScaleClient:
             "updated_before": updated_before,
             "updated_after": updated_after,
             "unique_id": unique_id,
+            "include_attachment_url": include_attachment_url,
         }
 
         if status:

--- a/scaleapi/_version.py
+++ b/scaleapi/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.14.3"
+__version__ = "2.14.4"
 __package_name__ = "scaleapi"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -407,6 +407,19 @@ def test_get_tasks():
     ):
         assert task.id in task_ids
 
+def test_get_tasks_returns_attachment():
+    batch = create_a_batch()
+    tasks = []
+    for _ in range(1):
+        tasks.append(make_a_task(batch=batch.name))
+    for task in client.get_tasks(
+        project_name=TEST_PROJECT_NAME,
+        batch_name=batch.name,
+        include_attachment_url=True,
+    ):
+        assert task.as_dict()['attachmentS3Downloads']
+
+
 
 def test_get_tasks_count():
     tasks_count = client.tasks(project=TEST_PROJECT_NAME).total


### PR DESCRIPTION
# Pull Request Summary

includes flag to return presigned s3 url's for attachments
as found here: https://docs.scale.com/reference/list-multiple-tasks

## Description

includes flag to return presigned s3 url's for attachments
as found here: https://docs.scale.com/reference/list-multiple-tasks

## How did you test your code?
`test_get_tasks_returns_attachment`

_Which of the following have you done to test your changes? Please describe the tests that you ran to verify your changes._
- [x] Created new unit tests in `tests/` for the newly implemented methods
- [ ] Updated existing unit tests in `tests/` to cover changes made to existing methods


## Checklist

_Please make sure all items in this checklist have been fulfilled before sending your PR out for review!_

- [ ] I have commented my code in details, particularly in hard-to-understand areas
- [ ] I have updated [Readme.rst](https://github.com/scaleapi/scaleapi-python-client/blob/master/README.rst) document with examples for newly implemented public methods
- [ ] I have reviewed [Deployment and Publishing Guide for Python SDK](https://github.com/scaleapi/scaleapi-python-client/blob/master/docs/pypi_update_guide.md) document
- [ ] I incremented the SDK version in `_version.py` _(unless this PR only updates the documentation)._
- [ ] In order to release a new version, a "Release Summary" needs to be prepared and published after the merge
