### PR TITLE
remove project from template schema

### DIFF
--- a/scaleapi/_version.py
+++ b/scaleapi/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.15.3"
+__version__ = "2.15.4"
 __package_name__ = "scaleapi"

--- a/scaleapi/projects.py
+++ b/scaleapi/projects.py
@@ -5,7 +5,6 @@ class TaskTemplate:
         self._json = json
         self._client = client
         self.id = json["id"]
-        self.project = json["project"]
         self.version = json["version"]
         self.created_at = json["created_at"]
         self.updated_at = json["updated_at"]

--- a/scaleapi/projects.py
+++ b/scaleapi/projects.py
@@ -14,7 +14,7 @@ class TaskTemplate:
         return hash(self.id)
 
     def __str__(self):
-        return f"TaskTemplate(id={self.id}, project={self.project})"
+        return f"TaskTemplate(id={self.id})"
 
     def __repr__(self):
         return f"TaskTemplate({self._json})"


### PR DESCRIPTION
fixes small bug causing template_fetching to crash since project is no longer returned in the schema