### PR TITLE
Adding limit option to get_tasks method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ Retrieve List of Tasks
 
 Retrieve a list of `Task` objects, with filters for: ``project_name``, ``batch_name``, ``type``, ``status``,
 ``review_status``, ``unique_id``, ``completed_after``, ``completed_before``, ``updated_after``, ``updated_before``,
-``created_after``, ``created_before``, ``tags`` and ``limited_response``.
+``created_after``, ``created_before``, ``tags``, ``limited_response`` and ``limit``.
 
 ``get_tasks()`` is a **generator** method and yields ``Task`` objects.
 

--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -335,6 +335,7 @@ class ScaleClient:
         tags: Union[List[str], str] = None,
         include_attachment_url: bool = True,
         limited_response: bool = None,
+        limit: int = None,
     ) -> Generator[Task, None, None]:
         """Retrieve all tasks as a `generator` method, with the
         given parameters. This methods handles pagination of
@@ -401,7 +402,10 @@ class ScaleClient:
             limited_response (bool):
                 If true, returns task response of the following fields:
                 task_id, status, metadata, project, otherVersion.
-
+            
+            limit (int):
+                Determines the task count per request (1-100)
+                For large sized tasks, use a smaller limit
 
         Yields:
             Generator[Task]:
@@ -428,6 +432,9 @@ class ScaleClient:
             include_attachment_url,
             limited_response,
         )
+
+        if limit:
+            tasks_args["limit"] = limit
 
         while has_more:
             tasks_args["next_token"] = next_token

--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -402,7 +402,7 @@ class ScaleClient:
             limited_response (bool):
                 If true, returns task response of the following fields:
                 task_id, status, metadata, project, otherVersion.
-            
+
             limit (int):
                 Determines the task count per request (1-100)
                 For large sized tasks, use a smaller limit

--- a/scaleapi/_version.py
+++ b/scaleapi/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.15.5"
+__version__ = "2.15.6"
 __package_name__ = "scaleapi"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -406,6 +406,7 @@ def test_get_tasks():
     for task in client.get_tasks(
         project_name=TEST_PROJECT_NAME,
         batch_name=batch.name,
+        limit=1,
     ):
         assert task.id in task_ids
 


### PR DESCRIPTION
# Pull Request Summary

## Description

Adding `limit` option to `get_tasks` method to allow selecting a certain limit for every pull from API. 
Limit is propagated to `/tasks` endpoint.

## How did you test your code?

_Which of the following have you done to test your changes? Please describe the tests that you ran to verify your changes._
- [ ] Created new unit tests in `tests/` for the newly implemented methods
- [x] Updated existing unit tests in `tests/` to cover changes made to existing methods


## Checklist

_Please make sure all items in this checklist have been fulfilled before sending your PR out for review!_

- [x] I have commented my code in details, particularly in hard-to-understand areas
- [x] I have updated [Readme.rst](https://github.com/scaleapi/scaleapi-python-client/blob/master/README.rst) document with examples for newly implemented public methods
- [x] I have reviewed [Deployment and Publishing Guide for Python SDK](https://github.com/scaleapi/scaleapi-python-client/blob/master/docs/pypi_update_guide.md) document
- [x] I incremented the SDK version in `_version.py` _(unless this PR only updates the documentation)._
- [x] In order to release a new version, a "Release Summary" needs to be prepared and published after the merge
