### PR TITLE
Handle missing raw and retries on Response

### DIFF
--- a/scaleapi/api.py
+++ b/scaleapi/api.py
@@ -144,10 +144,10 @@ class Api:
                 # Some endpoints only return 'OK' message without JSON
                 return json
         elif res.status_code == 409 and "task" in endpoint and body.get("unique_id"):
-            retry_history = None
-            if "retries" in res.raw and "history" in res.raw.retries:
+            try:
                 retry_history = res.raw.retries.history
-
+            except AttributeError:
+                retry_history = []
             # Example RequestHistory tuple
             # RequestHistory(method='POST',
             #   url='/v1/task/imageannotation',


### PR DESCRIPTION
# Pull Request Summary

## Description

Handle potentially missing `raw` and `retries` attributes of Response elegantly, in case they're not populated by the underlying request/urllib3 objects.

## How did you test your code?

_Which of the following have you done to test your changes? Please describe the tests that you ran to verify your changes._
- [ ] Created new unit tests in `tests/` for the newly implemented methods
- [ ] Updated existing unit tests in `tests/` to cover changes made to existing methods


## Checklist

_Please make sure all items in this checklist have been fulfilled before sending your PR out for review!_

- [x] I have commented my code in details, particularly in hard-to-understand areas
- [ ] I have updated [Readme.rst](https://github.com/scaleapi/scaleapi-python-client/blob/master/README.rst) document with examples for newly implemented public methods
- [x] I have reviewed [Deployment and Publishing Guide for Python SDK](https://github.com/scaleapi/scaleapi-python-client/blob/master/docs/pypi_update_guide.md) document
- [x] I incremented the SDK version in `_version.py` _(unless this PR only updates the documentation)._
- [x] In order to release a new version, a "Release Summary" needs to be prepared and published after the merge
