### PR TITLE
Make project name optional

### DIFF
--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -345,7 +345,7 @@ class ScaleClient:
         `task_list = list(get_tasks(...))`
 
         Args:
-            project_name (str):
+            project_name (str, optional):
                 Project Name
 
             batch_name (str, optional):

--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -413,11 +413,13 @@ class ScaleClient:
         """
 
         if not project_name and not batch_name:
-            raise ValueError("At least one of project_name or batch_name must be provided.")
-    
+            raise ValueError(
+                "At least one of project_name or batch_name must be provided."
+            )
+
         next_token = None
         has_more = True
-    
+
         tasks_args = self._process_tasks_endpoint_args(
             project_name,
             batch_name,
@@ -435,13 +437,13 @@ class ScaleClient:
             include_attachment_url,
             limited_response,
         )
-    
+
         if limit:
             tasks_args["limit"] = limit
-    
+
         while has_more:
             tasks_args["next_token"] = next_token
-    
+
             tasks = self.tasks(**tasks_args)
             for task in tasks.docs:
                 yield task
@@ -569,8 +571,10 @@ class ScaleClient:
     ):
         """Generates args for /tasks endpoint."""
         if not project_name and not batch_name:
-            raise ValueError("At least one of project_name or batch_name must be provided.")
-    
+            raise ValueError(
+                "At least one of project_name or batch_name must be provided."
+            )
+
         tasks_args = {
             "start_time": created_after,
             "end_time": created_before,
@@ -584,7 +588,7 @@ class ScaleClient:
             "unique_id": unique_id,
             "include_attachment_url": include_attachment_url,
         }
-    
+
         if status:
             tasks_args["status"] = status.value
         if limited_response:
@@ -596,9 +600,9 @@ class ScaleClient:
                 value = ",".join(map(lambda x: x.value, review_status))
             else:
                 value = review_status.value
-    
+
             tasks_args["customer_review_status"] = value
-    
+
         return tasks_args
 
     def create_task(self, task_type: TaskType, **kwargs) -> Task:

--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -412,6 +412,9 @@ class ScaleClient:
                 Yields Task objects, can be iterated.
         """
 
+        if not project_name and not batch_name:
+            raise ValueError("Either project_name or batch_name must be provided")
+
         next_token = None
         has_more = True
 

--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -413,11 +413,11 @@ class ScaleClient:
         """
 
         if not project_name and not batch_name:
-            raise ValueError("Either project_name or batch_name must be provided")
-
+            raise ValueError("At least one of project_name or batch_name must be provided.")
+    
         next_token = None
         has_more = True
-
+    
         tasks_args = self._process_tasks_endpoint_args(
             project_name,
             batch_name,
@@ -435,13 +435,13 @@ class ScaleClient:
             include_attachment_url,
             limited_response,
         )
-
+    
         if limit:
             tasks_args["limit"] = limit
-
+    
         while has_more:
             tasks_args["next_token"] = next_token
-
+    
             tasks = self.tasks(**tasks_args)
             for task in tasks.docs:
                 yield task
@@ -568,6 +568,9 @@ class ScaleClient:
         limited_response: bool = None,
     ):
         """Generates args for /tasks endpoint."""
+        if not project_name and not batch_name:
+            raise ValueError("At least one of project_name or batch_name must be provided.")
+    
         tasks_args = {
             "start_time": created_after,
             "end_time": created_before,
@@ -581,7 +584,7 @@ class ScaleClient:
             "unique_id": unique_id,
             "include_attachment_url": include_attachment_url,
         }
-
+    
         if status:
             tasks_args["status"] = status.value
         if limited_response:
@@ -593,9 +596,9 @@ class ScaleClient:
                 value = ",".join(map(lambda x: x.value, review_status))
             else:
                 value = review_status.value
-
+    
             tasks_args["customer_review_status"] = value
-
+    
         return tasks_args
 
     def create_task(self, task_type: TaskType, **kwargs) -> Task:

--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -320,7 +320,7 @@ class ScaleClient:
 
     def get_tasks(
         self,
-        project_name: str,
+        project_name: str = None,
         batch_name: str = None,
         task_type: TaskType = None,
         status: TaskStatus = None,
@@ -548,7 +548,7 @@ class ScaleClient:
 
     @staticmethod
     def _process_tasks_endpoint_args(
-        project_name: str,
+        project_name: str = None,
         batch_name: str = None,
         task_type: TaskType = None,
         status: TaskStatus = None,

--- a/scaleapi/_version.py
+++ b/scaleapi/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.15.10"
+__version__ = "2.15.11"
 __package_name__ = "scaleapi"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -503,3 +503,19 @@ def test_list_teammates():
 #     assert len(new_teammates) >= len(
 #         old_teammates
 #     )  # needs to sleep for teammates list to be updated
+
+def test_get_tasks_without_project_name():
+    tasks = client.get_tasks()
+    assert isinstance(tasks, list)
+
+def test_get_tasks_with_optional_project_name():
+    tasks = client.get_tasks(project_name=None)
+    assert isinstance(tasks, list)
+    
+def test_process_tasks_endpoint_args_without_project_name():
+    args = client._process_tasks_endpoint_args()
+    assert args["project_name"] is None
+
+def test_process_tasks_endpoint_args_with_optional_project_name():
+    args = client._process_tasks_endpoint_args(project_name=None)
+    assert args["project_name"] is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -505,17 +505,40 @@ def test_list_teammates():
 #     )  # needs to sleep for teammates list to be updated
 
 def test_get_tasks_without_project_name():
-    tasks = client.get_tasks()
-    assert isinstance(tasks, list)
+    with pytest.raises(ValueError):
+        list(client.get_tasks())
 
 def test_get_tasks_with_optional_project_name():
-    tasks = client.get_tasks(project_name=None)
-    assert isinstance(tasks, list)
-    
-def test_process_tasks_endpoint_args_without_project_name():
-    args = client._process_tasks_endpoint_args()
-    assert args["project_name"] is None
+    batch = create_a_batch()
+    tasks = []
+    for _ in range(3):
+        tasks.append(make_a_task(batch=batch.name))
+    task_ids = {task.id for task in tasks}
+    for task in client.get_tasks(
+        project_name=None,
+        batch_name=batch.name,
+        limit=1,
+    ):
+        assert task.id in task_ids
 
 def test_process_tasks_endpoint_args_with_optional_project_name():
-    args = client._process_tasks_endpoint_args(project_name=None)
-    assert args["project_name"] is None
+    args = client._process_tasks_endpoint_args(project_name=None, batch_name="test_batch")
+    assert args["project"] is None
+    assert args["batch"] == "test_batch"
+
+def test_get_tasks_with_batch_name():
+    batch = create_a_batch()
+    tasks = []
+    for _ in range(3):
+        tasks.append(make_a_task(batch=batch.name))
+    task_ids = {task.id for task in tasks}
+    for task in client.get_tasks(
+        batch_name=batch.name,
+        limit=1,
+    ):
+        assert task.id in task_ids
+
+def test_process_tasks_endpoint_args_with_batch_name():
+    args = client._process_tasks_endpoint_args(batch_name="test_batch")
+    assert args["project"] is None
+    assert args["batch"] == "test_batch"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -542,8 +542,3 @@ def test_get_tasks_with_batch_name():
     ):
         assert task.id in task_ids
         
-
-def test_process_tasks_endpoint_args_with_batch_name():
-    args = client._process_tasks_endpoint_args(batch_name="test_batch")
-    assert args["project"] is None
-    assert args["batch"] == "test_batch"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -504,9 +504,11 @@ def test_list_teammates():
 #         old_teammates
 #     )  # needs to sleep for teammates list to be updated
 
+
 def test_get_tasks_without_project_name():
     with pytest.raises(ValueError):
         list(client.get_tasks())
+
 
 def test_get_tasks_with_optional_project_name():
     batch = create_a_batch()
@@ -521,10 +523,14 @@ def test_get_tasks_with_optional_project_name():
     ):
         assert task.id in task_ids
 
+
 def test_process_tasks_endpoint_args_with_optional_project_name():
-    args = client._process_tasks_endpoint_args(project_name=None, batch_name="test_batch")
+    args = client._process_tasks_endpoint_args(
+        project_name=None, batch_name="test_batch"
+    )
     assert args["project"] is None
     assert args["batch"] == "test_batch"
+
 
 def test_get_tasks_with_batch_name():
     batch = create_a_batch()
@@ -537,6 +543,7 @@ def test_get_tasks_with_batch_name():
         limit=1,
     ):
         assert task.id in task_ids
+
 
 def test_process_tasks_endpoint_args_with_batch_name():
     args = client._process_tasks_endpoint_args(batch_name="test_batch")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -541,4 +541,3 @@ def test_get_tasks_with_batch_name():
         limit=1,
     ):
         assert task.id in task_ids
-        

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -525,9 +525,7 @@ def test_get_tasks_with_optional_project_name():
 
 
 def test_process_tasks_endpoint_args_with_optional_project_name():
-    args = client._process_tasks_endpoint_args(
-        project_name=None, batch_name="test_batch"
-    )
+    args = client._process_tasks_endpoint_args(batch_name="test_batch")
     assert args["project"] is None
     assert args["batch"] == "test_batch"
 
@@ -543,7 +541,7 @@ def test_get_tasks_with_batch_name():
         limit=1,
     ):
         assert task.id in task_ids
-
+        
 
 def test_process_tasks_endpoint_args_with_batch_name():
     args = client._process_tasks_endpoint_args(batch_name="test_batch")


### PR DESCRIPTION
# Pull Request Summary

## What's changed

**Optional `project_name` Parameter for `get_tasks()` Function in Python SDK**

**Description:**
This release includes an important update to the Scale API Python SDK that makes the `project_name` parameter optional for the `get_tasks()` function. Previously, `project_name` was a required parameter, which limited the flexibility of querying tasks. 

**Usage:**
- When calling `get_tasks()`, you can now omit the `project_name` parameter:

    ```python
    tasks = scale_client.get_tasks(batch_name='example_batch', status='TaskStatus.Completed')
    ```
- The function will work correctly with just the `batch_name` and `status` parameters, enhancing flexibility and ease of use.

**Additional Notes:**
- This change is backward-compatible; existing code with the `project_name` parameter will continue to function without modification.

Thank you for using the Scale API Python SDK! If you have any questions or encounter any issues, please reach out to our support team.

---

Feel free to adjust any details to fit your specific needs or internal documentation style.