### PR TITLE
Make project_name optional for get_tasks_count

### DIFF
--- a/scaleapi/__init__.py
+++ b/scaleapi/__init__.py
@@ -452,7 +452,7 @@ class ScaleClient:
 
     def get_tasks_count(
         self,
-        project_name: str,
+        project_name: str = None,
         batch_name: str = None,
         task_type: TaskType = None,
         status: TaskStatus = None,
@@ -470,7 +470,7 @@ class ScaleClient:
         """Returns number of tasks with given filters.
 
         Args:
-            project_name (str):
+            project_name (str, optional):
                 Project Name
 
             batch_name (str, optional):
@@ -528,6 +528,11 @@ class ScaleClient:
             int:
                 Returns number of tasks
         """
+
+        if not project_name and not batch_name:
+            raise ValueError(
+                "At least one of project_name or batch_name must be provided."
+            )
 
         tasks_args = self._process_tasks_endpoint_args(
             project_name,

--- a/scaleapi/_version.py
+++ b/scaleapi/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.15.12"
+__version__ = "2.15.13"
 __package_name__ = "scaleapi"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -417,6 +417,13 @@ def test_get_tasks_count():
     assert tasks_count == get_tasks_count
 
 
+def test_get_tasks_count_with_only_batch():
+    batch = create_a_batch()
+    tasks_count = client.tasks(batch=batch.name).total
+    get_tasks_count = client.get_tasks_count(batch_name=batch.name)
+    assert tasks_count == get_tasks_count
+
+
 def test_finalize_batch():
     batch = create_a_batch()
     batch = client.finalize_batch(batch.name)


### PR DESCRIPTION
# Pull Request Summary

## Description

`project_name` will be optional for `get_tasks_count` method. 
Providing either project or batch name will be enough to be consumed with the method.


## How did you test your code?

_Which of the following have you done to test your changes? Please describe the tests that you ran to verify your changes._
- [x] Created new unit tests in `tests/` for the newly implemented methods
- [ ] Updated existing unit tests in `tests/` to cover changes made to existing methods


## Checklist

_Please make sure all items in this checklist have been fulfilled before sending your PR out for review!_

- [x] I have commented my code in details, particularly in hard-to-understand areas
- [ ] I have updated [Readme.rst](https://github.com/scaleapi/scaleapi-python-client/blob/master/README.rst) document with examples for newly implemented public methods
- [x] I have reviewed [Deployment and Publishing Guide for Python SDK](https://github.com/scaleapi/scaleapi-python-client/blob/master/docs/pypi_update_guide.md) document
- [x] I incremented the SDK version in `_version.py` _(unless this PR only updates the documentation)._
- [x] In order to release a new version, a "Release Summary" needs to be prepared and published after the merge
