### PR TITLE
Fix publish twine version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           command: | # install env dependencies
             set -e
             pip install --upgrade pip
-            pip install twine
+            pip install twine==6.0.1
       - run:
           name: Build and Validate
           command: | # create whl, validate with twine

--- a/publish.sh
+++ b/publish.sh
@@ -61,7 +61,7 @@ if ! python3 setup.py sdist bdist_wheel > /dev/null 2>&1; then echo "ERROR: Pack
 if ! pip show twine > /dev/null 2>&1;
 then
     echo "WARN: 'twine' package is not found, installing...";
-    pip install twine
+    pip install twine==6.0.1
 fi
 
 # Twine Validation


### PR DESCRIPTION
# Pull Request Summary

Fix publish twine version. Currently gives this error when publishing: `InvalidDistribution: Invalid distribution metadata: unrecognized or malformed field 'license-file'`