### PR TITLE
Update Cruise Control External Task Type

### DIFF
--- a/scaleapi/_version.py
+++ b/scaleapi/_version.py
@@ -1,2 +1,2 @@
-__version__ = "2.18.2"
+__version__ = "2.18.3"
 __package_name__ = "scaleapi"

--- a/scaleapi/tasks.py
+++ b/scaleapi/tasks.py
@@ -35,7 +35,7 @@ class TaskType(Enum):
     ChatLite = "chatlite"
     MultiChat = "multichat"
     MultiStage = "multistage"
-    CruiseControl = "federal2dvideoannotation"
+    Federal2dVideoAnnotation = "federal2dvideoannotation"
 
 
 class TaskReviewStatus(Enum):

--- a/scaleapi/tasks.py
+++ b/scaleapi/tasks.py
@@ -35,7 +35,7 @@ class TaskType(Enum):
     ChatLite = "chatlite"
     MultiChat = "multichat"
     MultiStage = "multistage"
-    CruiseControl = "cruisecontrol"
+    CruiseControl = "federal2dvideoannotation"
 
 
 class TaskReviewStatus(Enum):


### PR DESCRIPTION
# Pull Request Summary

## Context

The server now exposes cruise control tasks under the external type name `federal2dvideoannotation` instead of `cruisecontrol`. This affects:

- Task creation endpoint: `/task/federal2dvideoannotation`
- Task type in API responses: `"federal2dvideoannotation"`

## Change

**File: [scaleapi/tasks.py](scaleapi/tasks.py)**

Update line 38 from:

```python
CruiseControl = "cruisecontrol"
```

to:

```python
CruiseControl = "federal2dvideoannotation"
```

This single change propagates to the relevant usages in [scaleapi/**init**.py](scaleapi/__init__.py):

- Task creation endpoint becomes `task/federal2dvideoannotation` (line 721)
- Task listing filter becomes `type=federal2dvideoannotation` (line 690)


## Description

_Please include a summary of the changes. Please also include the relevant context and motivation. List any dependencies and assumptions that are required for this change._


## How did you test your code?

_Which of the following have you done to test your changes? Please describe the tests that you ran to verify your changes._
- [ ] Created new unit tests in `tests/` for the newly implemented methods
- [ ] Updated existing unit tests in `tests/` to cover changes made to existing methods


## Checklist

_Please make sure all items in this checklist have been fulfilled before sending your PR out for review!_

- [ ] I have commented my code in details, particularly in hard-to-understand areas
- [ ] I have updated [Readme.rst](https://github.com/scaleapi/scaleapi-python-client/blob/master/README.rst) document with examples for newly implemented public methods
- [ ] I have reviewed [Deployment and Publishing Guide for Python SDK](https://github.com/scaleapi/scaleapi-python-client/blob/master/docs/pypi_update_guide.md) document
- [ ] I incremented the SDK version in `_version.py` _(unless this PR only updates the documentation)._
- [ ] In order to release a new version, a "Release Summary" needs to be prepared and published after the merge

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `CruiseControl` entry in the `TaskType` enum to reflect the new backend API type name `federal2dvideoannotation`. Both the enum member name and its string value are updated (`CruiseControl = "cruisecontrol"` → `Federal2dVideoAnnotation = "federal2dvideoannotation"`), which correctly aligns the enum key with its value per the project's constant-naming convention. The SDK version is bumped from `2.18.2` to `2.18.3`.

Key points:
- The enum rename correctly addresses the name/value mismatch flagged in previous review.
- Removing the public symbol `TaskType.CruiseControl` is a **breaking change** for any existing SDK consumer; a patch version bump (`2.18.3`) does not communicate this to users following semver — a minor or major bump would be more appropriate.
- No deprecation alias or migration path is provided for callers using `TaskType.CruiseControl`.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge if the breaking change is intentional and communicated; the version bump should be reconsidered.
- The change itself is minimal and mechanically correct — the enum key and value now align. However, removing a public symbol (`TaskType.CruiseControl`) without a deprecation path or a semver-appropriate version bump creates a real risk of silently breaking existing SDK consumers who upgrade.
- `scaleapi/_version.py` — version bump understates the breaking nature of the change; `scaleapi/tasks.py` — no backward-compatibility alias provided for removed enum member.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scaleapi/tasks.py | Renames enum member `CruiseControl` → `Federal2dVideoAnnotation` and updates its value from `"cruisecontrol"` to `"federal2dvideoannotation"` to match the new backend API type name; this is a breaking change for existing SDK consumers who reference `TaskType.CruiseControl`. |
| scaleapi/_version.py | Bumps version from `2.18.2` to `2.18.3`; given the breaking enum rename in `tasks.py`, a patch bump understates the severity of the change per semver conventions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["SDK Consumer calls\nTaskType.CruiseControl"] -->|Before PR| B["Value: 'cruisecontrol'\nAPI endpoint: /task/cruisecontrol"]
    A -->|After PR - AttributeError| E["❌ AttributeError: CruiseControl not found"]

    C["SDK Consumer calls\nTaskType.Federal2dVideoAnnotation"] -->|After PR| D["Value: 'federal2dvideoannotation'\nAPI endpoint: /task/federal2dvideoannotation"]

    style E fill:#ff6b6b,color:#fff
    style D fill:#51cf66,color:#fff
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scaleapi/tasks.py
Line: 38

Comment:
**Breaking change warrants a higher version bump**

Renaming `TaskType.CruiseControl` to `TaskType.Federal2dVideoAnnotation` removes a public enum member entirely. Any downstream code that references `TaskType.CruiseControl` will raise an `AttributeError` after upgrading. This is a **breaking API change** for existing SDK consumers.

Per semantic versioning, removing or renaming a public symbol qualifies as a breaking change and should increment the **minor** version at minimum (e.g. `2.19.0`) or the **major** version (e.g. `3.0.0`) if the project treats the public API as stable. The current bump to `2.18.3` (a patch release) signals only a backwards-compatible bug fix, which is misleading to consumers who rely on the changelog and version number to decide when to upgrade.

If backward compatibility is a concern, consider keeping the old member as a deprecated alias alongside the new one:

```python
Federal2dVideoAnnotation = "federal2dvideoannotation"
CruiseControl = "federal2dvideoannotation"  # Deprecated alias; use Federal2dVideoAnnotation
```

This allows existing users to migrate without immediately breaking.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["bump version"](https://github.com/scaleapi/scaleapi-python-client/commit/2a01c27cc5f7adb6533cfe03b9dc15f9e126c9ee)</sub>

**Context used:**

- Rule used - Constants should accurately reflect their actual v... ([source](https://app.greptile.com/review/custom-context?memory=329791ab-6f7e-4616-9bbc-cb41f96a2d1d))

**Learnt From**
[scaleapi/scaleapi#127157](https://github.com/scaleapi/scaleapi/pull/127157)

<!-- /greptile_comment -->