### PR TITLE
test: drop retired documenttranscription task type from test matrix

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -220,24 +220,6 @@ def test_imageannotation_fail():
         )
 
 
-def test_documenttranscription_ok():
-    client.create_task(
-        TaskType.DocumentTranscription,
-        instruction="Please transcribe this receipt.",
-        attachment="http://document.scale.com/receipt-20200519.jpg",
-        features=[{"type": "block", "label": "barcode"}],
-    )
-
-
-def test_documenttranscription_fail():
-    with pytest.raises(ScaleInvalidRequest):
-        client.create_task(
-            TaskType.DocumentTranscription,
-            callback_url="http://www.example.com/callback",
-            instruction="Please transcribe this receipt.",
-        )
-
-
 def test_annotation_ok():
     client.create_task(
         TaskType.Annotation,


### PR DESCRIPTION
## Why

scaleapi/scaleapi#152618 (merged 2026-07-22) removes `POST /v1/task/documenttranscription` from the monolith. The standard master→release deploy train auto-promotes to production on a schedule, so this is time-sensitive: once it deploys, this SDK's pytest suite will start failing against prod.

`tests/test_client.py` has two tests (`test_documenttranscription_ok`, `test_documenttranscription_fail`) that call `client.create_task(TaskType.DocumentTranscription, ...)`, hitting the endpoint being removed. This PR drops just those two tests from the matrix.

**Evidence**: 6 APM spans on 2026-07-12 hitting this endpoint, UA `scaleapi/2.18.4 ... pytest`, account `evan.x.wang+worker@scale.com`, all creating test-mode-only tasks (`testtasks` collection) — i.e. this SDK's own CI, not customer traffic.

**Scope note**: only the test matrix is touched. `TaskType.DocumentTranscription` / `TaskType.DocumentModel` remain in `scaleapi/tasks.py` and the `create_evaluation_task`/`create_training_task` docstrings in `scaleapi/__init__.py`, since those are runtime surfaces customers may still use for historical reads or other (non-removed) endpoints. No `DocumentModel` test existed to remove.

**Urgency**: please prioritize review/merge — the release train can promote master to prod on its normal schedule, and once it does, `master` CI here breaks until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Drops two integration tests (`test_documenttranscription_ok`, `test_documenttranscription_fail`) that called the now-retired `POST /v1/task/documenttranscription` endpoint, preventing CI failures once the removal reaches production.

- The `TaskType.DocumentTranscription` enum value and related docstrings in `scaleapi/tasks.py` and `scaleapi/__init__.py` are intentionally left in place, as customers may still use them for historical reads against other endpoints.
- No production code is modified; only the test matrix is reduced.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only two test functions are deleted, and all remaining tests continue to target live endpoints.

The change is purely subtractive: two test functions that would have started failing once the retired endpoint reaches production are removed. No production code, no SDK surface, and no other tests are touched. The remaining test suite is unaffected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/test_client.py | Removes test_documenttranscription_ok and test_documenttranscription_fail to stop hitting the retired POST /v1/task/documenttranscription endpoint; no other tests or logic affected. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pytest suite runs] --> B{TaskType?}
    B -- DocumentTranscription --> C[POST /v1/task/documenttranscription]
    C -- endpoint retired --> D[❌ 404 / error — CI breaks]
    B -- Annotation / ImageAnnotation / etc. --> E[POST /v1/task/... still live]
    E --> F[✅ Tests pass]

    style C stroke:#f00,stroke-width:2px
    style D stroke:#f00,stroke-width:2px
    style F stroke:#0a0,stroke-width:2px

    G[This PR] --> H[Removes DocumentTranscription tests from matrix]
    H --> B
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: drop retired documenttranscription..."](https://github.com/scaleapi/scaleapi-python-client/commit/065d5f535226240e169af420a53712f152cb64b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46418212)</sub>

<!-- /greptile_comment -->